### PR TITLE
Optionally specify statusline format

### DIFF
--- a/autoload/accio.vim
+++ b/autoload/accio.vim
@@ -87,11 +87,12 @@ function! accio#next_warning(forward, visual_mode) abort
 endfunction
 
 
-function! accio#statusline()
+function! accio#statusline(...)
+    let format = get(a:000, 0, "Errors: %d")
+    let no_errors = get(a:000, 1, printf(format, 0))
     let bufnr = bufnr("%")
-    let statusline = "Errors: "
     let error_count = len(get(s:accio_line_errors, bufnr, {}))
-    return statusline . error_count
+    return error_count ? printf(format, error_count) : no_errors
 endfunction
 
 

--- a/doc/accio.txt
+++ b/doc/accio.txt
@@ -115,7 +115,7 @@ Mappings                                                      *accio-mappings*
 ==============================================================================
 Statusline                                                  *accio-statusline*
 
-accio#statusline()                                        *accio#statusline()*
+accio#statusline([{fmt}[, {noerr}]])                      *accio#statusline()*
                         Accio provides a statusline function that will report
                         the number of errors in the current buffer.
 
@@ -123,6 +123,15 @@ accio#statusline()                                        *accio#statusline()*
                             set statusline+=%#WarningMsg#
                             set statusline+=%{accio#statusline()}
                             set statusline+=%*
+<
+                        When {fmt} is supplied as a string containing a "%d"
+                        placeholder, it is used as the format string for
+                        displaying the number of errors: >
+                            accio#statusline("Errors: %d")
+<
+                        The optional argument {noerr} specifies the output
+                        when there are no errors (otherwise, {fmt} is used): >
+                            accio#statusline("Errors: %d", "No errors")
 <
 
 ==============================================================================


### PR DESCRIPTION
First of all, I really appreciate the simplicity of Accio, and in particular that there is very little configuration to be done. This is my attempt to address #18 in a flexible way without introducing more global variables for configuration, taking inspiration from [vim-obsession](https://github.com/tpope/vim-obsession/blob/master/plugin/obsession.vim#L82-L99).

I've added two optional arguments to `accio#statusline()`. For example, for error counts 0 and 5

```
accio#statusline()
```

produces, respectively

```
"Errors: 0" or "Errors: 5"
```

This is compatible with the current implementation. The format can be specified in the first argument as a printf-style string:

```
accio#statusline("%d errors")
```

produces, respectively

```
"0 errors" or "5 errors"
```

A second argument can be supplied to specify the output when there are no errors:

```
accio#statusline("%d errors", "No errors")
```

produces, respectively

```
"No errors" or "5 errors"
```

This last option is particularly useful for passing an empty string if you don't want to show any indicator when there are no errors.

What do you think?

**Note**: I've intentionally left this feature undocumented, but I'd be happy to add it to the docs if you think appropriate.
