### PR TITLE
Public API

### DIFF
--- a/autoload/accio.vim
+++ b/autoload/accio.vim
@@ -21,8 +21,21 @@ let s:errors_by_line = {}
 " ======================================================================
 " Public API
 " ======================================================================
-function! accio#accio(tasks) abort
-    let tasks = type(args) == type("") ? [a:tasks] : a:tasks
+function! accio#accio(...) abort
+    let args = get(a:000, 0, [])
+    let focus = get(a:000, 1, 0)
+    let tasks = type(args) == type("") ? [args] : args
+
+    if empty(tasks)
+        if exists("g:accio_focus") && !empty(g:accio_focus)
+            let tasks = g:accio_focus
+        else
+            let inferred = get(b:, "accio", get(b:, "current_compiler", []))
+            let tasks = type(inferred) == type("") ? [inferred] : inferred
+        endif
+    elseif focus
+        let g:accio_focus = tasks
+    endif
 
     if empty(tasks)
         echohl ErrorMsg | echo "Accio: no task specified" | echohl None
@@ -34,6 +47,11 @@ function! accio#accio(tasks) abort
     else
         call s:accio_do_sync(tasks)
     endif
+endfunction
+
+
+function! accio#obliviate() abort
+    unlet! g:accio_focus
 endfunction
 
 

--- a/doc/accio.txt
+++ b/doc/accio.txt
@@ -67,7 +67,7 @@ g:accio_update_interval                              *g:accio_update_interval*
 ==============================================================================
 Commands                                                      *accio-commands*
 
-:Accio {arguments}                                                    *:Accio*
+:Accio {tasks}                                                        *:Accio*
                         Invokes the 'makeprg' specified by the compiler
                         plugins passed to the command and displays any
                         errors/warnings reported.  If |g:accio_auto_copen| is
@@ -88,6 +88,18 @@ Commands                                                      *accio-commands*
                         a list, otherwise Vim will attempt to resolve them as
                         variable names and throw an error
 
+:Accio                                                               *b:accio*
+                        Invokes |:Accio| with the arguments found in b:accio.
+                        If not set, falls back to b:current_compiler.
+
+:Accio! {tasks}
+                        Focus and execute {tasks}.  Same as |:Accio| but
+                        remembers the arguments such that they are reused in
+                        subsequent invocations (globally) without having to
+                        specify the {tasks} again.
+
+:Accio!
+                        Forget the currently focused task(s).
 
 ==============================================================================
 Mappings                                                      *accio-mappings*

--- a/plugin/accio.vim
+++ b/plugin/accio.vim
@@ -43,11 +43,7 @@ augroup accio
     autocmd CursorMoved * call accio#echo_message()
 augroup END
 
-if has("nvim")
-    command! -nargs=+ -complete=compiler Accio call accio#accio(<q-args>)
-else
-    command! -nargs=+ -complete=compiler Accio call accio#accio_vim(<q-args>)
-endif
+command! -bar -nargs=+ -complete=compiler Accio call accio#accio(accio#parse_args(<q-args>))
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo

--- a/plugin/accio.vim
+++ b/plugin/accio.vim
@@ -43,7 +43,12 @@ augroup accio
     autocmd CursorMoved * call accio#echo_message()
 augroup END
 
-command! -bar -nargs=+ -complete=compiler Accio call accio#accio(accio#parse_args(<q-args>))
+command! -bang -bar -nargs=? -complete=compiler Accio
+            \ if empty(<q-args>) && <bang>0 |
+            \     call accio#obliviate() |
+            \ else |
+            \     call accio#accio(accio#parse_args(<q-args>), <bang>0) |
+            \ endif
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
I've been sitting on these changes for a couple weeks. They aim to make programmatic usage of Accio easier. My motivation is wanting to call `:Accio` in a `BufWritePost` autocommand. It's a little cumbersome to pass a list of tasks to the command in a variable, so it makes more sense to call the function in that case. Furthermore, the user must decide between `accio#accio()` and `accio#accio_vim()` if s/he wishes to do so. The first change eliminates `accio#accio_vim()` in favor of one function that chooses the appropriate handler itself. It is also no longer responsible for parsing the argument to `:Accio`.

My first approach to defining which tasks to run per file type was to set buffer-local autocommands. This proved to be a slight hassle, so I instead settled on something like:

``` vim
augroup init_accio
  autocmd!
  autocmd BufWritePost * if exists("b:accio") | call accio#accio(b:accio) | endif
augroup END
```

That way, I need only set a buffer var per file type. (I'm not sure whether or not this will explode if a buffer other than the current buffer is written, e.g., `:wall`. Haven't tried it.)

This still leaves a problem of wanting to call `:Accio` interactively with the current tasks without having to specify them, so I opted to explore #5. I discarded the possibility of supporting `b:dispatch` early on. Although it sounded like a good idea to me at first, there are a couple problems in that it can contain things that aren't compilers as well as potentially containing Vim script commands. For example, if you set it via projectionist.vim, you can wind up with something like `ProjectDo Dispatch mycompiler`. So my second change is supporting `b:accio` as a fallback when no arguments are provided to `:Accio`.

My third change is introducing the concept of "focusing" a task. Given that you may want to run a task several times without specifying the tasks each time and without disturbing `b:accio`, I added something like `:FocusDispatch` but a bit simpler:

``` vim
Accio! foo  " Run 'foo' and remember it for next time
Accio       " Subsequent invocations without arguments run 'foo'
Accio!      " Forget the task
Accio       " Subsequent invocations fall back to b:accio (or fail if not set)
```

Note that a task is focused _globally_ rather than per buffer, which seems more intuitive (less to keep track of mentally) and distinguishes it from the `b:accio` use case. (This may step on your plans for #7.) These last couple of changes make `:Accio<CR>` a rather attractive normal-mode mapping.

I'm not married to these changes in their current form, but they've been useful. What do you think? Totally open to refining any and all of these ideas or even discarding them.

—N
